### PR TITLE
Updated logic to work with new architecture

### DIFF
--- a/helpers/create-bulk-body.js
+++ b/helpers/create-bulk-body.js
@@ -1,4 +1,8 @@
-module.exports = ({ marketplace, marketplaceStockData }) => {
+module.exports = stockData => {
+  return stockData.flatMap(buildMarketplaceBulk)
+}
+
+function buildMarketplaceBulk ({ marketplace, marketplaceStockData }) {
   const warehouse = `amz_${marketplace.toLowerCase()}`
   return getStockBulkBody(warehouse, marketplaceStockData).concat(getWarehouseBulkBody(warehouse))
 }

--- a/set-amz-stocks.js
+++ b/set-amz-stocks.js
@@ -2,14 +2,13 @@ module.exports.handler = async (event) => {
   const createBulkBody = require('./helpers/create-bulk-body.js')
   const setStocks = require('./helpers/set-es-stocks.js')
   console.log(JSON.stringify(event, null, 2))
-  return true
-  // return await setStocks(createBulkBody(event.responsePayload))
-  // .then(res => {
-  //   console.log(JSON.stringify(res, null, 2))
-  //   return res
-  // })
-  // .catch(err => {
-  //   console.log(JSON.stringify(err, null, 2))
-  //   return err
-  // })
+  return await setStocks(createBulkBody(event.detail.responsePayload.stockData))
+  .then(res => {
+    console.log(JSON.stringify(res, null, 2))
+    return res
+  })
+  .catch(err => {
+    console.log(JSON.stringify(err, null, 2))
+    return err
+  })
 }


### PR DESCRIPTION
**Changes description**
Updated lambda logic to work with new architecture. The event pulled from the `stocks` event bus now contains a `stockData` array of object which describes the stock data for each marketplaces.

**Updated features**
- _`create-bulk-body` helper:_ instead of handling one marketplace at a time, we now have all marketplaces data at once (for one region). Therefore the former processing logic is now applied to each marketplace and the overall bulk update body is built by concatenating each individual bodies together.
- _lambda handler:_ passing proper data to helpers